### PR TITLE
:bug: fix(driver-details-page): fixing scrolled content bug

### DIFF
--- a/src/views/DriverDetailsView.vue
+++ b/src/views/DriverDetailsView.vue
@@ -27,6 +27,7 @@ let driverProfile = ref<DriverProfile>({
 
 onMounted(() => {
     document.body.classList.add('overflow-hidden'); // best solution found atm
+    window.scrollTo(0,0);
     getDriverProfile(route.params.id as string).then((res) => {
         driverProfile.value = res;
     });

--- a/src/views/GrandPrixDetails.vue
+++ b/src/views/GrandPrixDetails.vue
@@ -24,9 +24,6 @@ onMounted(async() => {
 <template>
   <div class="container">
     <NavBar/>
-    <div class="go-back-container">
-        <a class="go-back" @click="this.$router.go(-1)">&lt; Back</a>
-    </div>
     <div v-if="gp" class="gp-details">
       <div class="track">
         <div :class="`track-name`">


### PR DESCRIPTION
Fixing scrolled content on mobile devices caused by the 'overflow: hidden' property.